### PR TITLE
HTBHF-2474 Use earningsThresholdExceed on UCHousehold to be able to…

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/dwp/entity/v1/uc/UCHousehold.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/dwp/entity/v1/uc/UCHousehold.java
@@ -24,6 +24,9 @@ public class UCHousehold extends BaseEntity {
     @Column(name = "household_identifier")
     private String householdIdentifier;
 
+    @Column(name = "earnings_threshold_exceeded")
+    private boolean earningsThresholdExceeded;
+
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "household", orphanRemoval = true)
     @ToString.Exclude
     private final Set<UCAdult> adults = new HashSet<>();

--- a/api/src/test/java/uk/gov/dhsc/htbhf/dwp/factory/v2/IdentityAndEligibilityResponseFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/dwp/factory/v2/IdentityAndEligibilityResponseFactoryTest.java
@@ -27,6 +27,12 @@ class IdentityAndEligibilityResponseFactoryTest {
     }
 
     @Test
+    void shouldReturnNotEligibleWhenEarningsThresholdExceededResponse() {
+        UCHousehold household = aUCHouseholdWithEarningsThresholdExceeded();
+        runTest(household, aValidPersonDTOV2(), anIdentityMatchedEligibilityNotConfirmedResponse());
+    }
+
+    @Test
     void shouldReturnEverythingMatchedWithpregnantChildDOBMatchNotSuppliedResponse() {
         PersonDTOV2 person = aPersonDTOV2WithPregnantDependantDob(null);
         runTest(aUCHousehold(), person, anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(VerificationOutcome.NOT_SUPPLIED,

--- a/api/src/test/java/uk/gov/dhsc/htbhf/dwp/testhelper/v2/UCHouseholdTestDataFactoryV2.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/dwp/testhelper/v2/UCHouseholdTestDataFactoryV2.java
@@ -27,6 +27,16 @@ public class UCHouseholdTestDataFactoryV2 {
                 .addChild(MAGGIE);
     }
 
+    public static UCHousehold aUCHouseholdWithEarningsThresholdExceeded() {
+        return aUCHouseholdWithNoAdultsOrChildrenAndEarningsThresholdExceeded()
+                .build()
+                .addAdult(HOMER)
+                .addAdult(MARGE)
+                .addChild(BART)
+                .addChild(LISA)
+                .addChild(MAGGIE);
+    }
+
     public static UCHousehold aUCHouseholdWithChildren(UCChild... child) {
         UCHousehold ucHouseholdWithAdults = aUCHouseholdWithNoAdultsOrChildren()
                 .build()
@@ -59,6 +69,14 @@ public class UCHouseholdTestDataFactoryV2 {
     private static UCHousehold.UCHouseholdBuilder aUCHouseholdWithNoAdultsOrChildren() {
         return UCHousehold.builder()
                 .householdIdentifier(SIMPSON_UC_HOUSEHOLD_IDENTIFIER)
+                .build()
+                .toBuilder();
+    }
+
+    private static UCHousehold.UCHouseholdBuilder aUCHouseholdWithNoAdultsOrChildrenAndEarningsThresholdExceeded() {
+        return UCHousehold.builder()
+                .householdIdentifier(SIMPSON_UC_HOUSEHOLD_IDENTIFIER)
+                .earningsThresholdExceeded(true)
                 .build()
                 .toBuilder();
     }


### PR DESCRIPTION
…trigger an eligibility NOT_CONFIRMED status.

The earnings_threshold_exceeded column was not removed from the dwp_uc_household column so we can use it for this purpose.